### PR TITLE
Fix HACS domain name

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,7 @@
 {
   "name": "Home Chore Tracker",
   "render_readme": true,
-  "domain": "ha_chores",
+  "domain": "home_chores_tracker",
   "documentation": "https://github.com/drdurczok/ha_chores",
   "issue_tracker": "https://github.com/drdurczok/ha_chores/issues"
 }


### PR DESCRIPTION
## Summary
- ensure `hacs.json` uses the same domain as the integration

## Testing
- `python3 -m json.tool hacs.json`


------
https://chatgpt.com/codex/tasks/task_b_683c092f9630832c9ec76aaa28afb78f